### PR TITLE
feat: Add PDF upload, parsing, and display functionality

### DIFF
--- a/Components/Layout/NavMenu.razor
+++ b/Components/Layout/NavMenu.razor
@@ -19,6 +19,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="fileupload">
+                <span class="bi bi-file-earmark-arrow-up-fill-nav-menu" aria-hidden="true"></span> File Upload
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="counter">
                 <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Counter
             </NavLink>

--- a/Components/Pages/FileUpload.razor
+++ b/Components/Pages/FileUpload.razor
@@ -1,0 +1,64 @@
+@page "/fileupload"
+@using System.IO
+@using UglyToad.PdfPig
+@using UglyToad.PdfPig.Content
+
+<h3>Upload PDF</h3>
+
+<InputFile OnChange="HandleFileSelected" />
+
+@if (!string.IsNullOrEmpty(parsingMessage))
+{
+    <p>@parsingMessage</p>
+}
+
+@if (!string.IsNullOrEmpty(extractedText))
+{
+    <div class="text-container">
+        <h4>Extracted Text:</h4>
+        <pre>@extractedText</pre>
+    </div>
+}
+
+@code {
+    private string? extractedText;
+    private string? parsingMessage;
+
+    private async Task HandleFileSelected(InputFileChangeEventArgs e)
+    {
+        parsingMessage = "Parsing, please wait...";
+        extractedText = null;
+
+        var file = e.File;
+        if (file != null)
+        {
+            try
+            {
+                await using var memoryStream = new MemoryStream();
+                await file.OpenReadStream(maxAllowedSize: 51200000).CopyToAsync(memoryStream);
+                memoryStream.Position = 0;
+
+                using (var pdf = PdfDocument.Open(memoryStream))
+                {
+                    var text = new System.Text.StringBuilder();
+                    foreach (var page in pdf.GetPages())
+                    {
+                        text.AppendLine(page.Text);
+                    }
+                    extractedText = text.ToString();
+                    parsingMessage = "File parsed successfully!";
+                }
+            }
+            catch (Exception ex)
+            {
+                parsingMessage = $"Error: {ex.Message}";
+            }
+        }
+        else
+        {
+            parsingMessage = "No file selected.";
+        }
+
+        StateHasChanged();
+    }
+}

--- a/OFM.csproj
+++ b/OFM.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0-preview.7.25380.108" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0-preview.7.25380.108" />
     <PackageReference Include="MudBlazor" Version="8.11.0" />
+    <PackageReference Include="PdfPig" Version="0.1.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This commit introduces a new feature that allows users to upload a PDF file, parse its text content, and view the extracted text on a review page.

The following changes are included:
- A new Razor page `FileUpload.razor` has been created to handle the file upload and display the extracted text.
- The `PdfPig` NuGet package has been added to the project to enable PDF parsing.
- A navigation link to the new "File Upload" page has been added to the main navigation menu for easy access.